### PR TITLE
Improve color scheme persistence

### DIFF
--- a/fire-flake/modules/home-manager/programs/neovim/lua/keymap.lua
+++ b/fire-flake/modules/home-manager/programs/neovim/lua/keymap.lua
@@ -148,7 +148,6 @@ vim.keymap.set("n", "<leader>fd", function() Telescope("diagnostics") end, { des
 vim.keymap.set("n", "<leader>fm", function() Telescope("marks") end, { desc = "Jump to mark" })
 vim.keymap.set("n", "<leader>fp", function() Telescope("project") end, { desc = "Projects" })
 vim.keymap.set("n", "<leader>fs", function() Telescope("grapple tags") end, { desc = "Grapple tags" })
-vim.keymap.set("n", "<leader>fx", function() require("plugins.colorscheme").load() end, { desc = "Themes" })
 vim.keymap.set("n", "<leader>fz", function() require("plugins.colorscheme").pick() end, { desc = "Themes" })
 vim.keymap.set("n", "<leader>ft", function() Telescope("treesitter") end, { desc = "Symbols (Treesitter)" })
 

--- a/fire-flake/modules/home-manager/programs/neovim/lua/plugins/colorscheme.lua
+++ b/fire-flake/modules/home-manager/programs/neovim/lua/plugins/colorscheme.lua
@@ -55,27 +55,22 @@ function M.palette(timeout)
     "Special",
   }
 
-  -- build a colored bar using two spaces for each group
-  local bar = {}
-  for _ = 1, #groups do
-    table.insert(bar, "  ")
-  end
-  local lines = { table.concat(bar, "") }
-  vim.list_extend(lines, groups)
+  local lines = groups
 
   local buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
   vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   for i, grp in ipairs(groups) do
-    -- color the group name
-    vim.api.nvim_buf_add_highlight(buf, -1, grp, i, 0, -1)
-    -- color the bar segment
-    vim.api.nvim_buf_add_highlight(buf, -1, grp, 0, (i - 1) * 2, i * 2)
+    vim.api.nvim_buf_add_highlight(buf, -1, grp, i - 1, 0, -1)
   end
 
-  local width = math.max(20, #groups * 2)
-  local height = #groups + 1
+  local width = 0
+  for _, grp in ipairs(groups) do
+    width = math.max(width, #grp)
+  end
+  width = math.max(20, width + 2)
+  local height = #groups
   local win = vim.api.nvim_open_win(buf, false, {
     relative = "editor",
     width = width,

--- a/fire-flake/modules/home-manager/programs/neovim/lua/plugins/colorscheme.lua
+++ b/fire-flake/modules/home-manager/programs/neovim/lua/plugins/colorscheme.lua
@@ -106,8 +106,12 @@ function M.pick()
         if entry then
           local theme = entry.value
           actions.close(prompt_bufnr)
-          pcall(vim.cmd.colorscheme, theme)
-          M.palette()
+          local ok, err = pcall(vim.cmd.colorscheme, theme)
+          if ok then
+            M.palette()
+          else
+            vim.notify("Failed to load colorscheme: " .. theme .. " (" .. err .. ")", vim.log.levels.ERROR)
+          end
         else
           vim.notify("No colorscheme selected", vim.log.levels.WARN)
         end

--- a/fire-flake/modules/home-manager/programs/neovim/lua/plugins/colorscheme.lua
+++ b/fire-flake/modules/home-manager/programs/neovim/lua/plugins/colorscheme.lua
@@ -1,28 +1,91 @@
--- Telescope colorscheme picker with persistence
+-- Colorscheme utilities with Telescope picker and persistence
 local M = {}
 
-local config_path = vim.fn.stdpath("config") .. "/.colorscheme"
+-- location to persist the chosen theme
+local config_path = vim.fn.stdpath("state") .. "/colorscheme"
 
-function M.save(theme)
-  local f = io.open(config_path, "w")
-  if f then
-    f:write(theme)
-    f:close()
+local function write_theme(theme)
+  if theme and #theme > 0 then
+    vim.fn.mkdir(vim.fn.fnamemodify(config_path, ":h"), "p")
+    vim.fn.writefile({ theme }, config_path)
   end
 end
 
-function M.load()
-  local f = io.open(config_path, "r")
-  if f then
-    local theme = f:read("*l")
-    f:close()
-    if theme then
-      local ok, _ = pcall(vim.cmd.colorscheme, theme)
-      if not ok then
-        vim.notify("Failed to load colorscheme: " .. theme, vim.log.levels.ERROR)
-      end
+local function read_theme()
+  if vim.fn.filereadable(config_path) == 1 then
+    local t = vim.fn.readfile(config_path)[1]
+    if t and #t > 0 then
+      return t
     end
   end
+end
+
+function M.save(theme)
+  write_theme(theme or vim.g.colors_name)
+end
+
+function M.load()
+  local theme = read_theme()
+  if theme then
+    local ok, err = pcall(vim.cmd.colorscheme, theme)
+    if not ok then
+      vim.notify("Failed to load colorscheme: " .. theme .. " (" .. err .. ")", vim.log.levels.ERROR)
+    end
+  end
+end
+
+-- automatically persist on colorscheme change
+vim.api.nvim_create_autocmd("ColorScheme", {
+  callback = function()
+    M.save(vim.g.colors_name)
+  end,
+})
+
+-- simple floating palette showing some highlight groups
+function M.palette(timeout)
+  local groups = {
+    "Normal",
+    "Comment",
+    "Constant",
+    "String",
+    "Identifier",
+    "Statement",
+    "PreProc",
+    "Type",
+    "Special",
+  }
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
+  vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, groups)
+  for i, grp in ipairs(groups) do
+    vim.api.nvim_buf_add_highlight(buf, -1, grp, i - 1, 0, -1)
+  end
+
+  local width = 20
+  local height = #groups
+  local win = vim.api.nvim_open_win(buf, false, {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = 1,
+    col = vim.o.columns - width - 2,
+    style = "minimal",
+    border = "rounded",
+  })
+
+  vim.keymap.set("n", "q", function()
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
+  end, { buffer = buf, silent = true })
+
+  vim.defer_fn(function()
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
+  end, timeout or 1500)
 end
 
 function M.pick()
@@ -36,16 +99,15 @@ function M.pick()
         local entry = state.get_selected_entry()
         if entry then
           local theme = entry.value
-          vim.cmd.colorscheme(theme)
-          M.save(theme)
-          vim.notify("Colorscheme: " .. theme, vim.log.levels.INFO)
+          actions.close(prompt_bufnr)
+          pcall(vim.cmd.colorscheme, theme)
+          M.palette()
         else
           vim.notify("No colorscheme selected", vim.log.levels.WARN)
         end
-        actions.close(prompt_bufnr)
       end)
       return true
-    end
+    end,
   }
 end
 

--- a/fire-flake/modules/home-manager/programs/neovim/lua/plugins/colorscheme.lua
+++ b/fire-flake/modules/home-manager/programs/neovim/lua/plugins/colorscheme.lua
@@ -55,16 +55,27 @@ function M.palette(timeout)
     "Special",
   }
 
+  -- build a colored bar using two spaces for each group
+  local bar = {}
+  for _ = 1, #groups do
+    table.insert(bar, "  ")
+  end
+  local lines = { table.concat(bar, "") }
+  vim.list_extend(lines, groups)
+
   local buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
   vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, groups)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   for i, grp in ipairs(groups) do
-    vim.api.nvim_buf_add_highlight(buf, -1, grp, i - 1, 0, -1)
+    -- color the group name
+    vim.api.nvim_buf_add_highlight(buf, -1, grp, i, 0, -1)
+    -- color the bar segment
+    vim.api.nvim_buf_add_highlight(buf, -1, grp, 0, (i - 1) * 2, i * 2)
   end
 
-  local width = 20
-  local height = #groups
+  local width = math.max(20, #groups * 2)
+  local height = #groups + 1
   local win = vim.api.nvim_open_win(buf, false, {
     relative = "editor",
     width = width,

--- a/fire-flake/modules/home-manager/programs/neovim/lua/plugins/colorscheme.lua
+++ b/fire-flake/modules/home-manager/programs/neovim/lua/plugins/colorscheme.lua
@@ -85,7 +85,7 @@ function M.palette(timeout)
     if vim.api.nvim_win_is_valid(win) then
       vim.api.nvim_win_close(win, true)
     end
-  end, timeout or 1500)
+  end, timeout or 3000)
 end
 
 function M.pick()


### PR DESCRIPTION
## Summary
- make a more robust Neovim colour scheme utility
  - automatically save the selected theme on any `ColorScheme` event
  - store file in `stdpath("state")`
  - add a small palette window for quick preview
  - tweak Telescope picker integration

## Testing
- `nix flake check ./fire-flake` *(fails: unable to download from cache – 403)*

------
https://chatgpt.com/codex/tasks/task_e_684380685448832ab971220219ba880c