### PR TITLE
Add goose.nvim plugin

### DIFF
--- a/fire-flake/modules/home-manager/programs/neovim/lua/init.lua
+++ b/fire-flake/modules/home-manager/programs/neovim/lua/init.lua
@@ -72,6 +72,7 @@ local lazy_plugins = {
   "plugins.ux.noice",
   "plugins.ux.autosave",
   "plugins.ux.kulala",
+  "plugins.ux.goose",
   "plugins.debug.bqf",
   "plugins.ux.hydra",
   "plugins.ux.whichkey",

--- a/fire-flake/modules/home-manager/programs/neovim/lua/plugins/ux/goose.lua
+++ b/fire-flake/modules/home-manager/programs/neovim/lua/plugins/ux/goose.lua
@@ -1,0 +1,38 @@
+require('goose').setup({
+  prefered_picker = 'telescope',
+  default_global_keymaps = false,
+  providers = {
+    openai = {
+      'gpt-4.1',
+    },
+    anthropic = {
+      'claude-sonnet-4-20250514',
+    },
+  },
+})
+
+-- Helper for calling goose api functions
+local function Goose(action)
+  return function(...)
+    require('goose.api')[action](...)
+  end
+end
+
+-- Keymaps
+vim.keymap.set('n', '<leader>Ag', Goose('toggle'), { desc = 'Goose: Toggle UI' })
+vim.keymap.set('n', '<leader>Ai', Goose('open_input'), { desc = 'Goose: Open input' })
+vim.keymap.set('n', '<leader>AI', Goose('open_input_new_session'), { desc = 'Goose: New session input' })
+vim.keymap.set('n', '<leader>Ao', Goose('open_output'), { desc = 'Goose: Open output' })
+vim.keymap.set('n', '<leader>At', Goose('toggle_focus'), { desc = 'Goose: Toggle focus' })
+vim.keymap.set('n', '<leader>Aq', Goose('close'), { desc = 'Goose: Close UI' })
+vim.keymap.set('n', '<leader>Af', Goose('toggle_fullscreen'), { desc = 'Goose: Toggle fullscreen' })
+vim.keymap.set('n', '<leader>As', Goose('select_session'), { desc = 'Goose: Select session' })
+vim.keymap.set('n', '<leader>Ac', Goose('goose_mode_chat'), { desc = 'Goose: Chat mode' })
+vim.keymap.set('n', '<leader>Aa', Goose('goose_mode_auto'), { desc = 'Goose: Auto mode' })
+vim.keymap.set('n', '<leader>Ap', Goose('configure_provider'), { desc = 'Goose: Choose provider' })
+vim.keymap.set('n', '<leader>Ad', Goose('diff_open'), { desc = 'Goose: Diff open' })
+vim.keymap.set('n', '<leader>A]', Goose('diff_next'), { desc = 'Goose: Diff next file' })
+vim.keymap.set('n', '<leader>A[', Goose('diff_prev'), { desc = 'Goose: Diff previous file' })
+vim.keymap.set('n', '<leader>Ax', Goose('diff_close'), { desc = 'Goose: Diff close' })
+vim.keymap.set('n', '<leader>Ara', Goose('diff_revert_all'), { desc = 'Goose: Revert all changes' })
+vim.keymap.set('n', '<leader>Art', Goose('diff_revert_this'), { desc = 'Goose: Revert this file' })

--- a/fire-flake/modules/home-manager/programs/neovim/lua/plugins/ux/whichkey.lua
+++ b/fire-flake/modules/home-manager/programs/neovim/lua/plugins/ux/whichkey.lua
@@ -21,4 +21,5 @@ wk.add({
   { "<leader>q", group = "quick-fix", icon = "" },
   { "<leader>R", group = "REST", icon = "󰖆" },
   { "<leader>o", group = "obsidian", icon = "󰍉" },
+  { "<leader>A", group = "goose", icon = "🪿" },
 })

--- a/fire-flake/modules/home-manager/programs/neovim/plugins.nix
+++ b/fire-flake/modules/home-manager/programs/neovim/plugins.nix
@@ -26,6 +26,8 @@ with pkgs.vimPlugins; [
   hydra-nvim
   auto-save-nvim
   nurpkgs.kulala-nvim
+  nurpkgs.goose-nvim
+  pkgs.vimPlugins.render-markdown-nvim
 
   # UI
   lualine-nvim


### PR DESCRIPTION
## Summary
- include goose.nvim from nurpkgs with render-markdown dep
- configure goose.nvim with non-conflicting keymaps
- register goose plugin group in which-key
- load goose on VeryLazy event
- list available goose providers

## Testing
- `nix flake check --no-build --print-build-logs`


------
https://chatgpt.com/codex/tasks/task_e_68475a24ecb4832aace6987b3d52adf8