### PR TITLE
Add Claude Code CLI module

### DIFF
--- a/fire-flake/modules/home-manager/programs/claude-code.nix
+++ b/fire-flake/modules/home-manager/programs/claude-code.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.custom.claudeCode;
+in {
+  options.custom.claudeCode = {
+    enable = lib.mkEnableOption "Enable Claude Code CLI";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.claude-code;
+      description = "Claude Code package to install.";
+    };
+
+    extraEnv = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = {};
+      description = "Additional environment variables for Claude Code.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    home.sessionVariables = cfg.extraEnv;
+  };
+}

--- a/fire-flake/profiles/users/default/home.nix
+++ b/fire-flake/profiles/users/default/home.nix
@@ -11,6 +11,7 @@
     ../../../modules/home-manager/programs/neovim.nix
     ../../../modules/home-manager/programs/obsidian.nix
     ../../../modules/home-manager/programs/goose.nix
+    ../../../modules/home-manager/programs/claude-code.nix
     ../../../modules/home-manager/programs/fish.nix
     ../../../modules/home-manager/programs/starship/starship.nix
     ../../../modules/home-manager/common.nix
@@ -81,6 +82,14 @@
     model = "claude-4-sonnet";
     #extraEnv = {
     #  GOOSE_TEMPERATURE = "0.7";
+    #};
+  };
+
+  # Claude Code CLI
+  custom.claudeCode = {
+    enable = true;
+    #extraEnv = {
+    #  CLAUDE_CODE_MODEL = "default";
     #};
   };
 


### PR DESCRIPTION
## Summary
- add a Claude Code module under home-manager programs
- enable the module in the default user profile

## Testing
- `nix flake check --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684fca462fd0832a9c80d506b97425b1